### PR TITLE
Escape HTML output on Plugin Settings page, fix namespace mismatch, add Claude.

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -75,7 +75,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="ucscgiving"/>
+				<element value="ucsccomms"/>
 				<!-- <element value="library-textdomain"/> -->
 			</property>
 		</properties>
@@ -84,7 +84,7 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
-				<element value="ucscgiving"/>
+				<element value="ucsccomms"/>
 			</property>
 		</properties>
 	</rule>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### PHP
+```bash
+composer run lint        # PHP CodeSniffer (WordPress-Extra + WordPress-Docs standards)
+composer run lint-fix    # Auto-fix PHPCS violations
+```
+
+### Release & Packaging
+```bash
+npm run dryrun     # Preview version bump without committing
+npm run release    # Bump version via standard-version (updates plugin.php header + CHANGELOG.md)
+npm run zip        # Package plugin as .zip for distribution
+```
+
+`npm run release` uses `wp-plugin-version-updater.js` to keep the version string in the `plugin.php` header in sync alongside the standard `package.json` bump.
+
+## Architecture
+
+This is a single-purpose WordPress plugin that provides an **A-Z Editorial Style Guide** CPT backed by ACF Pro.
+
+### Core dependency
+**Advanced Custom Fields Pro** must be active. The plugin does not function without it.
+
+### Custom Post Type
+`a_z_style_guide` ("Editorial Style Guide") — publicly queryable, searchable, non-hierarchical. Registered in `plugin.php`.
+
+### ACF JSON
+Field group definitions live in `acf-json/`. The plugin filters `acf/settings/save_json` and `acf/settings/load_json` so ACF reads/writes field definitions from this directory rather than the database — keeping them version-controlled.
+
+- `group_5a1f2f21b2d3c.json` — field group with a `style_definitions` repeater (sub-fields: `editorial_style_item` text + `editorial_style_definition` WYSIWYG)
+- `post_type_685d7e97c87c6.json` — ACF-managed CPT definition
+
+### Shortcodes (`lib/functions/shortcodes.php`)
+- `[style-definition]` — renders the `style_definitions` repeater for the current post
+- `[style-archive]` — queries all `a_z_style_guide` posts and renders their definitions
+
+### Admin settings page (`lib/functions/settings.php`)
+Simple informational page under **Settings** showing plugin version (linked to GitHub releases) and feature list. Requires `manage_options` capability.
+
+### Namespace / autoloading
+`composer.json` defines PSR-4 autoloading: `UCSC\UcscCommunicationsFunctionality\` → `src/`. No `src/` directory exists yet; this is placeholder infrastructure. Current code uses procedural `require_once` includes.
+
+## Known quirks
+
+- No unit tests, no PHPStan config, no JS build pipeline (no blocks or interactive JS).

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -40,7 +40,7 @@ if ( ! function_exists( 'ucsccomms_render_plugin_settings_page' ) ) {
 		?>
 		<div class="wrap cf-admin-settings-page">
 		<h1><?php echo esc_html( $plugin_name ); ?></h1>
-		<h2><?php echo esc_html( __( 'Version:', 'ucsccomms' ) ); ?> <?php echo esc_html( $plugin_version ); ?> <a href="https://github.com/ucsc/ucsc-communications-functionality/releases"><?php echo esc_html( __( '(release notes)', 'ucsccomms' ) ); ?></a></h2>
+		<h2><?php echo esc_html( __( 'Version:', 'ucsccomms' ) ); ?> <?php echo esc_html( $plugin_version ); ?> <a href="<?php echo esc_url( 'https://github.com/ucsc/ucsc-communications-functionality/releases' ); ?>"><?php echo esc_html( __( '(release notes)', 'ucsccomms' ) ); ?></a></h2>
 		<p><?php echo wp_kses_post( $plugin_desc ); ?></p>
 		<hr>
 		<h3><?php echo esc_html( __( 'Features added by this plugin', 'ucsccomms' ) ); ?></h3>
@@ -51,13 +51,13 @@ if ( ! function_exists( 'ucsccomms_render_plugin_settings_page' ) ) {
 		</ul>
 		<h4><?php echo esc_html( __( 'ACF JSON', 'ucsccomms' ) ); ?></h4>
 		<p><?php
-			printf(
-				wp_kses(
+			echo wp_kses(
+				sprintf(
 					/* translators: %s: acf-json folder name in code tags */
 					__( "Field group definitions are saved to and loaded from the plugin's %s folder, which supports version control and syncing alongside ACF's database storage.", 'ucsccomms' ),
-					array( 'code' => array() )
+					'<code>acf-json</code>'
 				),
-				'<code>acf-json</code>'
+				array( 'code' => array() )
 			);
 		?></p>
 		</div>

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -35,20 +35,18 @@ if ( ! function_exists( 'ucsccomms_render_plugin_settings_page' ) ) {
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-communications-functionality/plugin.php');
 		?>
 		<div class="wrap cf-admin-settings-page">
-		<h1><?php echo $plugin_data['Name']; ?></h1>
-		<h2>Version: <?php echo $plugin_data['Version']; ?> <a href="https://github.com/ucsc/ucsc-communications-functionality/releases">(release notes)</a></h2>
-		<p><?php echo $plugin_data['Description']; ?></p>
+		<h1><?php echo esc_html( $plugin_data['Name'] ); ?></h1>
+		<h2>Version: <?php echo esc_html( $plugin_data['Version'] ); ?> <a href="https://github.com/ucsc/ucsc-communications-functionality/releases">(release notes)</a></h2>
+		<p><?php echo wp_kses_post( $plugin_data['Description'] ); ?></p>
 		<hr>
-		<h3>Features added by this plugin:</h3>
+		<h3>Features added by this plugin</h3>
+		<h4>Shortcodes</h4>
 		<ul>
-			<li><strong>Shortcodes:</strong>
-				<ul>
-					<li><code>[style-definition]</code>: Displays the style definitions for each Editorial Style Guide post type</li>
-					<li><code>[style-archive]</code>: Displays a loop of the style guide posts on the Editorial Style Guide page</li>
-				</ul>
-			</li>
-            <li><strong>ACF JSON:</strong> Saves and loads ACF field groups to/from the plugin's <code>acf-json</code> folder</li>
+			<li><code>[style-definition]</code> — Displays the style definitions for each Editorial Style Guide post.</li>
+			<li><code>[style-archive]</code> — Displays a loop of all Editorial Style Guide posts on an archive page.</li>
 		</ul>
+		<h4>ACF JSON</h4>
+		<p>Field group definitions are saved to and loaded from the plugin's <code>acf-json</code> folder, keeping them version-controlled rather than stored in the database.</p>
 		</div>
 		<?php
 	}

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -46,7 +46,7 @@ if ( ! function_exists( 'ucsccomms_render_plugin_settings_page' ) ) {
 			<li><code>[style-archive]</code> — Displays a loop of all Editorial Style Guide posts on an archive page.</li>
 		</ul>
 		<h4>ACF JSON</h4>
-		<p>Field group definitions are saved to and loaded from the plugin's <code>acf-json</code> folder, keeping them version-controlled rather than stored in the database.</p>
+		<p>Field group definitions are saved to and loaded from the plugin's <code>acf-json</code> folder, which supports version control and syncing alongside ACF's database storage.</p>
 		</div>
 		<?php
 	}

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -32,21 +32,34 @@ add_action( 'admin_menu', 'ucsccomms_add_settings_page' );
 
 if ( ! function_exists( 'ucsccomms_render_plugin_settings_page' ) ) {
 	function ucsccomms_render_plugin_settings_page() {
-		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/ucsc-communications-functionality/plugin.php');
+		$plugin_file = UCSCCOMMS_PLUGIN_DIR . 'plugin.php';
+		$plugin_data = file_exists( $plugin_file ) ? get_plugin_data( $plugin_file ) : array();
+		$plugin_name    = ! empty( $plugin_data['Name'] ) ? $plugin_data['Name'] : '';
+		$plugin_version = ! empty( $plugin_data['Version'] ) ? $plugin_data['Version'] : '';
+		$plugin_desc    = ! empty( $plugin_data['Description'] ) ? $plugin_data['Description'] : '';
 		?>
 		<div class="wrap cf-admin-settings-page">
-		<h1><?php echo esc_html( $plugin_data['Name'] ); ?></h1>
-		<h2>Version: <?php echo esc_html( $plugin_data['Version'] ); ?> <a href="https://github.com/ucsc/ucsc-communications-functionality/releases">(release notes)</a></h2>
-		<p><?php echo wp_kses_post( $plugin_data['Description'] ); ?></p>
+		<h1><?php echo esc_html( $plugin_name ); ?></h1>
+		<h2><?php echo esc_html( __( 'Version:', 'ucsccomms' ) ); ?> <?php echo esc_html( $plugin_version ); ?> <a href="https://github.com/ucsc/ucsc-communications-functionality/releases"><?php echo esc_html( __( '(release notes)', 'ucsccomms' ) ); ?></a></h2>
+		<p><?php echo wp_kses_post( $plugin_desc ); ?></p>
 		<hr>
-		<h3>Features added by this plugin</h3>
-		<h4>Shortcodes</h4>
+		<h3><?php echo esc_html( __( 'Features added by this plugin', 'ucsccomms' ) ); ?></h3>
+		<h4><?php echo esc_html( __( 'Shortcodes', 'ucsccomms' ) ); ?></h4>
 		<ul>
-			<li><code>[style-definition]</code> — Displays the style definitions for each Editorial Style Guide post.</li>
-			<li><code>[style-archive]</code> — Displays a loop of all Editorial Style Guide posts on an archive page.</li>
+			<li><code>[style-definition]</code> — <?php echo esc_html( __( 'Displays the style definitions for each Editorial Style Guide post.', 'ucsccomms' ) ); ?></li>
+			<li><code>[style-archive]</code> — <?php echo esc_html( __( 'Displays a loop of all Editorial Style Guide posts on an archive page.', 'ucsccomms' ) ); ?></li>
 		</ul>
-		<h4>ACF JSON</h4>
-		<p>Field group definitions are saved to and loaded from the plugin's <code>acf-json</code> folder, which supports version control and syncing alongside ACF's database storage.</p>
+		<h4><?php echo esc_html( __( 'ACF JSON', 'ucsccomms' ) ); ?></h4>
+		<p><?php
+			printf(
+				wp_kses(
+					/* translators: %s: acf-json folder name in code tags */
+					__( "Field group definitions are saved to and loaded from the plugin's %s folder, which supports version control and syncing alongside ACF's database storage.", 'ucsccomms' ),
+					array( 'code' => array() )
+				),
+				'<code>acf-json</code>'
+			);
+		?></p>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
This PR properly escapes the HTML output in the `settings.php` file, edits the Features list on the Settings page, and fixes a namespace mismatch. Fixes #2 